### PR TITLE
Fix for #4

### DIFF
--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -2,7 +2,7 @@
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <uri id="Imports Wizard Entry" name="http://www.w3.org/ns/prov-o-inverses-20130430" uri="http://www.w3.org/ns/prov"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1548772447644" name="http://www.semanticweb.org/milk/ontologies/2018/5/untitled-ontology-22" uri="slowmo.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1548772447644" name="http://www.w3.org/ns/csvw" uri="imports/csvw.xml"/>
+        <uri id="Automatically generated entry, Timestamp=1551468946652" name="http://www.semanticweb.org/milk/ontologies/2018/5/untitled-ontology-22" uri="slowmo.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1551468946652" name="http://www.w3.org/ns/csvw" uri="imports/csvw.xml"/>
     </group>
 </catalog>

--- a/slowmo.owl
+++ b/slowmo.owl
@@ -29,10 +29,10 @@ distributed under the License is distributed on an &amp;quot;AS IS&amp;quot; BAS
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License</rdfs:comment>
         <rdfs:comment>slomo is a working ontology-like structure in .owl used to define meta-terms, working-in-progress terms and IRIs needed for other knowledge-base processes. There is no import structure and currently no external dependancies.</rdfs:comment>
     </owl:Ontology>
+    
 
 
-
-    <!--
+    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Annotation properties
@@ -40,7 +40,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
@@ -49,52 +49,52 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:comment>Imported from the Information Artifact Ontology</rdfs:comment>
         <rdfs:label>definition</rdfs:label>
     </owl:AnnotationProperty>
-
+    
 
 
     <!-- http://purl.org/dc/terms/description -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/description"/>
-
+    
 
 
     <!-- http://purl.org/dc/terms/hasVersion -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/hasVersion"/>
-
+    
 
 
     <!-- http://purl.org/dc/terms/issued -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/issued"/>
-
+    
 
 
     <!-- http://purl.org/dc/terms/modified -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/modified"/>
-
+    
 
 
     <!-- http://purl.org/dc/terms/publisher -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/publisher"/>
-
+    
 
 
     <!-- http://purl.org/dc/terms/title -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/title"/>
-
+    
 
 
     <!-- http://www.w3.org/2004/02/skos/core#note -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#note"/>
+    
 
 
-
-    <!--
+    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Datatypes
@@ -102,16 +102,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-
+    
 
 
     <!-- http://www.w3.org/2001/XMLSchema#date -->
 
     <rdfs:Datatype rdf:about="http://www.w3.org/2001/XMLSchema#date"/>
+    
 
 
-
-    <!--
+    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Object Properties
@@ -119,7 +119,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-
+    
 
 
     <!-- http://example.com/slowmo#HasCandidate -->
@@ -127,7 +127,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:ObjectProperty rdf:about="http://example.com/slowmo#HasCandidate">
         <rdfs:label>has candidate</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://example.com/slowmo#IsAbout -->
@@ -135,7 +135,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:ObjectProperty rdf:about="http://example.com/slowmo#IsAbout">
         <rdfs:label>is about</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://example.com/slowmo#IsAboutISR -->
@@ -144,7 +144,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subPropertyOf rdf:resource="http://example.com/slowmo#IsAbout"/>
         <rdfs:label>is about ISR</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://example.com/slowmo#IsAboutPerformer -->
@@ -153,7 +153,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subPropertyOf rdf:resource="http://example.com/slowmo#IsAbout"/>
         <rdfs:label>is about performer</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://example.com/slowmo#IsAboutTemplate -->
@@ -162,7 +162,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subPropertyOf rdf:resource="http://example.com/slowmo#IsAbout"/>
         <rdfs:label xml:lang="en">is about template</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://example.com/slowmo#IsAcceptableBy -->
@@ -170,7 +170,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:ObjectProperty rdf:about="http://example.com/slowmo#IsAcceptableBy">
         <rdfs:label>is acceptable by</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://example.com/slowmo#IsPromotedBy -->
@@ -178,7 +178,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:ObjectProperty rdf:about="http://example.com/slowmo#IsPromotedBy">
         <rdfs:label>is promoted by</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://example.com/slowmo#Uses -->
@@ -186,7 +186,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:ObjectProperty rdf:about="http://example.com/slowmo#Uses">
         <rdfs:label>uses</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://example.com/slowmo#UsesInterventionProperty -->
@@ -195,7 +195,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subPropertyOf rdf:resource="http://example.com/slowmo#Uses"/>
         <rdfs:label>uses intervention property</rdfs:label>
     </owl:ObjectProperty>
-
+    
 
 
     <!-- http://purl.obolibrary.org/obo/RO_0000091 -->
@@ -205,10 +205,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:comment>Imported from the Relation Ontology</rdfs:comment>
         <rdfs:label>has disposition</rdfs:label>
     </owl:ObjectProperty>
+    
 
 
-
-    <!--
+    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Classes
@@ -216,52 +216,47 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-
+    
 
 
     <!-- http://example.com/slowmo#AddressCountry -->
 
     <owl:Class rdf:about="http://example.com/slowmo#AddressCountry">
-        <obo:IAO_0000115>Needed</obo:IAO_0000115>
         <rdfs:label>address country</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#AddressLocality -->
 
     <owl:Class rdf:about="http://example.com/slowmo#AddressLocality">
-        <obo:IAO_0000115>Needed</obo:IAO_0000115>
         <rdfs:label>address locality</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#AddressRegion -->
 
     <owl:Class rdf:about="http://example.com/slowmo#AddressRegion">
-        <obo:IAO_0000115></obo:IAO_0000115>
         <rdfs:label>address region</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#AncestorPerformer -->
 
     <owl:Class rdf:about="http://example.com/slowmo#AncestorPerformer">
-        <obo:IAO_0000115></obo:IAO_0000115>
         <rdfs:label>ancestor performer</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#AncestorTemplate -->
 
     <owl:Class rdf:about="http://example.com/slowmo#AncestorTemplate">
-        <obo:IAO_0000115></obo:IAO_0000115>
         <rdfs:label>ancestor template</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#AppropriateCandidate -->
@@ -271,7 +266,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <obo:IAO_0000115>A candidate thats situation and template characteristics are complementary according to theory</obo:IAO_0000115>
         <rdfs:label xml:lang="en">appropriate candidate</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#BehaviorChangeIntervention -->
@@ -281,7 +276,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:isDefinedBy>Michie S, Stralen MMV, West R. The behaviour change wheel: A new method for characterising and designing behaviour change interventions. Implementation Science. 2011;6(1).</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">behavior change intervention</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#Candidate -->
@@ -290,16 +285,23 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <obo:IAO_0000115>An independent continuant which represents the union of the features of a situation and those of a template</obo:IAO_0000115>
         <rdfs:label xml:lang="en">candidate</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#CapabilityBarrier -->
 
     <owl:Class rdf:about="http://example.com/slowmo#CapabilityBarrier">
-        <obo:IAO_0000115>Definition Needed</obo:IAO_0000115>
         <rdfs:label>capability barrier</rdfs:label>
     </owl:Class>
+    
 
+
+    <!-- http://example.com/slowmo#ColumnUse -->
+
+    <owl:Class rdf:about="http://example.com/slowmo#ColumnUse">
+        <rdfs:label>column use</rdfs:label>
+    </owl:Class>
+    
 
 
     <!-- http://example.com/slowmo#Delivery -->
@@ -309,7 +311,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:comment>Adapted from West, R. and Michie, S. (2016). A Guide to Development and Evaluation of Digital Behavior Interventions in Healthcare. Silverback Publishing.</rdfs:comment>
         <rdfs:label xml:lang="en">delivery</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#DimensionCardinality -->
@@ -317,7 +319,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:Class rdf:about="http://example.com/slowmo#DimensionCardinality">
         <rdfs:label>dimension cardinality</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#DominantPerformanceBehaviorCapability -->
@@ -328,7 +330,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <obo:IAO_0000115>A capability realized when a performer is able to consistently carry out a performance behavior at a high level of excellence</obo:IAO_0000115>
         <rdfs:label xml:lang="en">dominant performance behavior capability</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#Figure -->
@@ -336,7 +338,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:Class rdf:about="http://example.com/slowmo#Figure">
         <rdfs:label>figure</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#GapFigure -->
@@ -345,7 +347,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#Figure"/>
         <rdfs:label>gap figure</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#Guideline -->
@@ -353,7 +355,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:Class rdf:about="http://example.com/slowmo#Guideline">
         <rdfs:label>guideline</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#InputTable -->
@@ -361,7 +363,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:Class rdf:about="http://example.com/slowmo#InputTable">
         <rdfs:label>input table</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#InterventionSituationrRelationship -->
@@ -370,16 +372,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <obo:IAO_0000115>a causal pathway from an intervention to a situation</obo:IAO_0000115>
         <rdfs:label>intervention situation relationship</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#Location -->
 
     <owl:Class rdf:about="http://example.com/slowmo#Location">
-        <obo:IAO_0000115>def needed</obo:IAO_0000115>
         <rdfs:label xml:lang="en">location</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#MasteryPresent -->
@@ -387,7 +388,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:Class rdf:about="http://example.com/slowmo#MasteryPresent">
         <rdfs:label>mastery present</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#MasteryUnknown -->
@@ -395,7 +396,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:Class rdf:about="http://example.com/slowmo#MasteryUnknown">
         <rdfs:label>mastery unknown</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#Measure -->
@@ -403,7 +404,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:Class rdf:about="http://example.com/slowmo#Measure">
         <rdfs:label>measure</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#MeasureCardinality -->
@@ -412,7 +413,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#DimensionCardinality"/>
         <rdfs:label>measure cardinality</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#Name -->
@@ -420,7 +421,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:Class rdf:about="http://example.com/slowmo#Name">
         <rdfs:label>name</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#NegativePerformanceGap -->
@@ -429,7 +430,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#PerformanceGap"/>
         <rdfs:label>negative performance gap</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#NegativePerformanceSignal -->
@@ -439,7 +440,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <obo:IAO_0000115>A performance signal that indicates the performance is bad</obo:IAO_0000115>
         <rdfs:label>negative performance signal</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#NondominantPerformanceBehaviorCapability -->
@@ -449,16 +450,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <obo:IAO_0000115>A capability realized when a performer is not able to consistently carry out a performance behavior at a high level of excellence</obo:IAO_0000115>
         <rdfs:label xml:lang="en">nondominant performance behavior capability</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#NormativeComparator -->
 
     <owl:Class rdf:about="http://example.com/slowmo#NormativeComparator">
-        <obo:IAO_0000115>Definition Needed</obo:IAO_0000115>
         <rdfs:label>normative comparator</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#PeerComparison -->
@@ -466,7 +466,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:Class rdf:about="http://example.com/slowmo#PeerComparison">
         <rdfs:label>peer comparison</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#Performance -->
@@ -475,7 +475,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <obo:IAO_0000115>a determinable quality that is dependant on human beings organizations and instantiated by measurement values of a behavior process</obo:IAO_0000115>
         <rdfs:label xml:lang="en">performance</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#PerformanceBehaviorcCapability -->
@@ -484,7 +484,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <obo:IAO_0000115>A capability realized in the process of performing a performance behavior</obo:IAO_0000115>
         <rdfs:label xml:lang="en">performance behavior capability</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#PerformanceCardinality -->
@@ -493,7 +493,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#DimensionCardinality"/>
         <rdfs:label>performance cardinality</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#PerformanceGap -->
@@ -501,7 +501,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:Class rdf:about="http://example.com/slowmo#PerformanceGap">
         <rdfs:label>performance gap</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#PerformanceSignal -->
@@ -510,7 +510,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <obo:IAO_0000115>An indication of the state affairs of an accomplished behavior</obo:IAO_0000115>
         <rdfs:label>performance signal</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#PerformerCardinality -->
@@ -519,7 +519,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#DimensionCardinality"/>
         <rdfs:label>performer cardinality</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#PositivePerformanceGap -->
@@ -528,7 +528,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#PerformanceGap"/>
         <rdfs:label>positive performance gap</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#PositivePerformanceSignal -->
@@ -538,36 +538,33 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <obo:IAO_0000115>A performance signal that indicates the performance is good</obo:IAO_0000115>
         <rdfs:label>positive performance signal</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#PostalCode -->
 
     <owl:Class rdf:about="http://example.com/slowmo#PostalCode">
-        <obo:IAO_0000115>Needed</obo:IAO_0000115>
         <rdfs:label>postal code</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#PreventionFocus -->
 
     <owl:Class rdf:about="http://example.com/slowmo#PreventionFocus">
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#RegulatoryFocus"/>
-        <obo:IAO_0000115>definition needed</obo:IAO_0000115>
         <rdfs:label>prevention focus</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#PromotionFocus -->
 
     <owl:Class rdf:about="http://example.com/slowmo#PromotionFocus">
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#RegulatoryFocus"/>
-        <obo:IAO_0000115>Definition Needed</obo:IAO_0000115>
         <rdfs:label>promotion focus</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#RegulatoryFocus -->
@@ -576,7 +573,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <obo:IAO_0000115>a sensitivity of the recipient</obo:IAO_0000115>
         <rdfs:label>regulatory focus</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#RelatedLocation -->
@@ -585,7 +582,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#Location"/>
         <rdfs:label>related location</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#ShowsBigGap -->
@@ -594,7 +591,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#ShowsGap"/>
         <rdfs:label>shows big gap</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#ShowsGap -->
@@ -602,7 +599,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:Class rdf:about="http://example.com/slowmo#ShowsGap">
         <rdfs:label>shows gap</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#ShowsNegativeGap -->
@@ -611,7 +608,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#ShowsGap"/>
         <rdfs:label>shows negative gap</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#ShowsPositiveGap -->
@@ -620,7 +617,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#ShowsGap"/>
         <rdfs:label>shows positive gap</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#ShowsSmallGap -->
@@ -629,7 +626,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#ShowsGap"/>
         <rdfs:label>shows small gap</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#ShowsTrend -->
@@ -637,16 +634,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
     <owl:Class rdf:about="http://example.com/slowmo#ShowsTrend">
         <rdfs:label>shows trend</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#StreetAddress -->
 
     <owl:Class rdf:about="http://example.com/slowmo#StreetAddress">
-        <obo:IAO_0000115>Needed</obo:IAO_0000115>
         <rdfs:label>street address</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#TimeCardinality -->
@@ -655,7 +651,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#DimensionCardinality"/>
         <rdfs:label>time cardinality</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#TrendFigure -->
@@ -664,7 +660,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:subClassOf rdf:resource="http://example.com/slowmo#Figure"/>
         <rdfs:label>trend figure</rdfs:label>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#slowmo_0000010 -->
@@ -675,7 +671,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete behavior</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#slowmo_0000024 -->
@@ -687,7 +683,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete setting</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#slowmo_0000035 -->
@@ -698,7 +694,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete appraisal of performance behavior</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#slowmo_0000142 -->
@@ -707,29 +703,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsolete legacy terms</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-
+    
 
 
     <!-- http://example.com/slowmo#spek -->
 
     <owl:Class rdf:about="http://example.com/slowmo#spek">
-        <obo:IAO_0000115>def needed</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spek</rdfs:label>
     </owl:Class>
-
-
-
-    <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Annotations
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-  
 </rdf:RDF>
 
 
 
 <!-- Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi -->
+


### PR DESCRIPTION
1. Add term 'column use' to slowmo.
1. Remove unused 'definition' annotations. 'Needed' is not a helpful value, better to just add definition when appropriate. 